### PR TITLE
Fix Ruby 2.7 warnings

### DIFF
--- a/lib/paperclip/io_adapters/http_url_proxy_adapter.rb
+++ b/lib/paperclip/io_adapters/http_url_proxy_adapter.rb
@@ -9,8 +9,8 @@ module Paperclip
     REGEXP = /\Ahttps?:\/\//
 
     def initialize(target, options = {})
-      escaped = URI.escape(target)
-      super(URI(target == URI.unescape(target) ? escaped : target), options)
+      escaped = Paperclip::UrlGenerator.escape(target)
+      super(URI(target == Paperclip::UrlGenerator.unescape(target) ? escaped : target), options)
     end
   end
 end

--- a/lib/paperclip/io_adapters/uri_adapter.rb
+++ b/lib/paperclip/io_adapters/uri_adapter.rb
@@ -53,7 +53,7 @@ module Paperclip
     def download_content
       options = { read_timeout: Paperclip.options[:read_timeout] }.compact
 
-      open(@target, **options)
+      self.open(@target, options)
     end
 
     def copy_to_tempfile(src)

--- a/lib/paperclip/url_generator.rb
+++ b/lib/paperclip/url_generator.rb
@@ -3,6 +3,13 @@ require 'active_support/core_ext/module/delegation'
 
 module Paperclip
   class UrlGenerator
+    class << self
+      def encoder
+        @encoder ||= URI::RFC2396_Parser.new
+      end
+      delegate :escape, :unescape, to: :encoder
+    end
+
     def initialize(attachment)
       @attachment = attachment
     end
@@ -65,7 +72,7 @@ module Paperclip
       if url.respond_to?(:escape)
         url.escape
       else
-        URI.escape(url).gsub(escape_regex){|m| "%#{m.ord.to_s(16).upcase}" }
+        self.class.escape(url).gsub(escape_regex) { |m| "%#{m.ord.to_s(16).upcase}" }
       end
     end
 

--- a/spec/paperclip/io_adapters/http_url_proxy_adapter_spec.rb
+++ b/spec/paperclip/io_adapters/http_url_proxy_adapter_spec.rb
@@ -65,6 +65,10 @@ describe Paperclip::HttpUrlProxyAdapter do
       @subject.original_filename = 'image.png'
       assert_equal 'image.png', @subject.original_filename
     end
+
+    it "doesn't emit deprecation warnings" do
+      expect { subject }.to_not(output(/URI\.(un)?escape is obsolete/).to_stderr)
+    end
   end
 
   context "a url with query params" do

--- a/spec/paperclip/url_generator_spec.rb
+++ b/spec/paperclip/url_generator_spec.rb
@@ -194,6 +194,16 @@ describe Paperclip::UrlGenerator do
       "expected the interpolator to be passed #{expected.inspect} but it wasn't"
   end
 
+  it "doesn't emit deprecation warnings" do
+    expected = "the expected result"
+    mock_interpolator = MockInterpolator.new(result: expected)
+    options = { interpolator: mock_interpolator }
+    mock_attachment = MockAttachment.new(options)
+    url_generator = Paperclip::UrlGenerator.new(mock_attachment)
+
+    expect { url_generator.for(:style_name, escape: true) }.to_not(output(/URI\.(un)?escape is obsolete/).to_stderr)
+  end
+
   describe "should be able to escape (, ), [, and ]." do
     def generate(expected, updated_at=nil)
       mock_interpolator = MockInterpolator.new(result: expected)


### PR DESCRIPTION
Disables the warnings when using Easel such as /bundle/bundler/gems/paperclip-e3f7493b4cc9/lib/paperclip/url_generator.rb:68: warning: URI.escape is obsolete
This PR is heavily based on https://github.com/kreeti/kt-paperclip/pull/38 with changes cherry picked to avoid further changes that kt-paperclip has introduced

I have run a CircleCI build of branch of Easel using the new build on `stop-2.7-spam` and results can be seen in https://app.circleci.com/pipelines/github/inventables/easel/9391/workflows/c6a8badd-906c-4aa8-8a46-4c19b0a2d0a4/jobs/44961. Warnings are no longer present in the build log. Tested locally paperclip is still working as intended.